### PR TITLE
Fix #60

### DIFF
--- a/includes/admin/class-alg-wc-custom-order-numbers-settings-general.php
+++ b/includes/admin/class-alg-wc-custom-order-numbers-settings-general.php
@@ -222,15 +222,6 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Settings_General' ) ) :
 					),
 					array(
 						'title'             => __( 'Select orders to apply new settings to', 'custom-order-numbers-for-woocommerce' ),
-						'desc'              => apply_filters(
-							'alg_wc_custom_order_numbers',
-							'<br>' . sprintf(
-								'You will need <a href="%s" target="_blank">%s</a> plugin to set this option.',
-								'https://www.tychesoftwares.com/store/premium-plugins/custom-order-numbers-woocommerce/?utm_source=conupgradetopro&utm_medium=link&utm_campaign=CustomOrderNumbersLite',
-								'Custom Order Numbers for WooCommerce Pro'
-							),
-							'settings'
-						),
 						'desc_tip'          => __( 'This will add the prefix/suffix from the particular date.', 'custom-order-numbers-for-woocommerce' ),
 						'id'                => 'alg_wc_custom_order_numbers_settings_to_apply',
 						'default'           => 'all_orders',
@@ -241,7 +232,19 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Settings_General' ) ) :
 							'date'       => __( 'To orders from a specific date', 'custom-order-numbers-for-woocommerce' ),
 							'all_orders' => __( 'To all orders', 'custom-order-numbers-for-woocommerce' ),
 						),
-						'custom_attributes' => apply_filters( 'alg_wc_custom_order_numbers', array( 'disabled' => 'disabled' ), 'settings' ),
+						'custom_attributes' => apply_filters( 'alg_wc_custom_order_numbers', array(), 'settings' ),
+					),
+					array(
+						'title' => __( 'Select a Date to apply this new settings from', 'custom-order-numbers-for-woocommerce' ),
+						'desc'  => __( ' <b>Note</b> : Only applies to past dates.', 'custom-order-numbers-for-woocommerce' ),
+						'id'    => 'alg_wc_custom_order_numbers_settings_to_apply_from_date',
+						'type'  => 'text',
+					),
+					array(
+						'title' => __( 'Enter an Order Id from which you want to apply this new settings', 'custom-order-numbers-for-woocommerce' ),
+						'desc'  => __( ' <b>Note</b> : Please enter a past order number.', 'custom-order-numbers-for-woocommerce' ),
+						'id'    => 'alg_wc_custom_order_numbers_settings_to_apply_from_order_id',
+						'type'  => 'text',
 					),
 					array(
 						'title'   => __( 'Enable order tracking by custom number', 'custom-order-numbers-for-woocommerce' ),

--- a/includes/js/con-dismiss-notice.js
+++ b/includes/js/con-dismiss-notice.js
@@ -33,7 +33,6 @@ jQuery(document).ready(function($) {
 			});
     	}
 	);
-
     var con_apply_setting_value = $( '#alg_wc_custom_order_numbers_settings_to_apply' ).val();
     if ( con_apply_setting_value === 'new_order' || con_apply_setting_value === 'all_orders' ) {
         $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).hide();
@@ -58,25 +57,24 @@ jQuery(document).ready(function($) {
             $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).hide();
         }
     });
-
+    
     var today = new Date();
-    $( '#alg_wc_custom_order_numbers_settings_to_apply_from_date' ).datepicker(
-        {
-            format: 'mm-dd-yyyy',
-            autoclose:true,
-            endDate: "today",
-            maxDate: today
-        } ).on(
+    $( '#alg_wc_custom_order_numbers_settings_to_apply_from_date' ).datepicker( {
+        format: 'mm-dd-yyyy',
+        autoclose:true,
+        endDate: "today",
+        maxDate: today
+    } ).on(
         'changeDate',
         function (ev) {
             $( this ).datepicker( 'hide' );
         }
     );
-        $( '#alg_wc_custom_order_numbers_settings_to_apply_from_date' ).keyup(
-            function () {
-                if ( this.value.match( /[^0-9]/g ) ) {
-                    this.value = this.value.replace( /[^0-9^-]/g, '' );
-                }
+    $( '#alg_wc_custom_order_numbers_settings_to_apply_from_date' ).keyup(
+        function () {
+            if ( this.value.match( /[^0-9]/g ) ) {
+                this.value = this.value.replace( /[^0-9^-]/g, '' );
             }
-        );
+        }
+    );
 });

--- a/includes/js/con-dismiss-notice.js
+++ b/includes/js/con-dismiss-notice.js
@@ -62,7 +62,7 @@ jQuery(document).ready(function($) {
         {
             format: 'mm-dd-yyyy',
             autoclose: true,
-            endDate: "today",
+            endDate: 'today',
             maxDate: today,
         }
     ).on(

--- a/includes/js/con-dismiss-notice.js
+++ b/includes/js/con-dismiss-notice.js
@@ -51,7 +51,7 @@ jQuery(document).ready(function($) {
         } else {
             $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]' ).closest( 'tr' ).hide();
         }
-        if ( con_apply_setting_value == 'date' ) {
+        if ( con_apply_setting_value === 'date' ) {
             $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).show();
         } else {
             $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).hide();        }
@@ -61,7 +61,7 @@ jQuery(document).ready(function($) {
     $( '#alg_wc_custom_order_numbers_settings_to_apply_from_date' ).datepicker(
         {
             format: 'mm-dd-yyyy',
-            autoclose:true,
+            autoclose: true,
             endDate: "today",
             maxDate: today,
         }

--- a/includes/js/con-dismiss-notice.js
+++ b/includes/js/con-dismiss-notice.js
@@ -34,44 +34,49 @@ jQuery(document).ready(function($) {
     	}
 	);
 
-    var con_apply_setting_value = $('#alg_wc_custom_order_numbers_settings_to_apply').val();
-    if ( con_apply_setting_value == 'new_order' || con_apply_setting_value == 'all_orders' ) {
-
-        $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]').closest('tr').hide();
-        $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]').closest('tr').hide();
+    var con_apply_setting_value = $( '#alg_wc_custom_order_numbers_settings_to_apply' ).val();
+    if ( con_apply_setting_value === 'new_order' || con_apply_setting_value === 'all_orders' ) {
+        $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).hide();
+        $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]' ).closest( 'tr' ).hide();
     }
-    if ( con_apply_setting_value == 'order_id' ) {
-        $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]').closest('tr').hide();
+    if ( con_apply_setting_value === 'order_id' ) {
+        $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).hide();
     }
-    if ( con_apply_setting_value == 'date' ) {
-        $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]').closest('tr').hide();
+    if ( con_apply_setting_value === 'date' ) {
+        $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]' ).closest( 'tr' ).hide();
     }
-    $('#alg_wc_custom_order_numbers_settings_to_apply').change( function(){
-        var con_apply_setting_value = $('#alg_wc_custom_order_numbers_settings_to_apply').val();
-        if ( con_apply_setting_value == 'order_id' ) {
-            $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]').closest('tr').show();
+    $('#alg_wc_custom_order_numbers_settings_to_apply').change( function() {
+        var con_apply_setting_value = $( '#alg_wc_custom_order_numbers_settings_to_apply' ).val();
+        if ( con_apply_setting_value === 'order_id' ) {
+            $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]' ).closest( 'tr' ).show();
         } else {
-            $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]').closest('tr').hide();
+            $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]' ).closest( 'tr' ).hide();
         }
         if ( con_apply_setting_value == 'date' ) {
-            $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]').closest('tr').show();
+            $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).show();
         } else {
-            $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]').closest('tr').hide();
+            $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).hide();
         }
     });
 
     var today = new Date();
-    $('#alg_wc_custom_order_numbers_settings_to_apply_from_date').datepicker({
-        format: 'mm-dd-yyyy',
-        autoclose:true,
-        endDate: "today",
-        maxDate: today
-    }).on('changeDate', function (ev) {
-            $(this).datepicker('hide');
-        });
-    $('#alg_wc_custom_order_numbers_settings_to_apply_from_date').keyup(function () {
-        if (this.value.match(/[^0-9]/g)) {
-            this.value = this.value.replace(/[^0-9^-]/g, '');
+    $( '#alg_wc_custom_order_numbers_settings_to_apply_from_date' ).datepicker(
+        {
+            format: 'mm-dd-yyyy',
+            autoclose:true,
+            endDate: "today",
+            maxDate: today
+        } ).on(
+        'changeDate',
+        function (ev) {
+            $( this ).datepicker( 'hide' );
         }
-    });
+    );
+        $( '#alg_wc_custom_order_numbers_settings_to_apply_from_date' ).keyup(
+            function () {
+                if ( this.value.match( /[^0-9]/g ) ) {
+                    this.value = this.value.replace( /[^0-9^-]/g, '' );
+                }
+            }
+        );
 });

--- a/includes/js/con-dismiss-notice.js
+++ b/includes/js/con-dismiss-notice.js
@@ -54,17 +54,18 @@ jQuery(document).ready(function($) {
         if ( con_apply_setting_value == 'date' ) {
             $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).show();
         } else {
-            $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).hide();
-        }
+            $( '[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]' ).closest( 'tr' ).hide();        }
     });
     
     var today = new Date();
-    $( '#alg_wc_custom_order_numbers_settings_to_apply_from_date' ).datepicker( {
-        format: 'mm-dd-yyyy',
-        autoclose:true,
-        endDate: "today",
-        maxDate: today
-    } ).on(
+    $( '#alg_wc_custom_order_numbers_settings_to_apply_from_date' ).datepicker(
+        {
+            format: 'mm-dd-yyyy',
+            autoclose:true,
+            endDate: "today",
+            maxDate: today,
+        }
+    ).on(
         'changeDate',
         function (ev) {
             $( this ).datepicker( 'hide' );

--- a/includes/js/con-dismiss-notice.js
+++ b/includes/js/con-dismiss-notice.js
@@ -33,4 +33,45 @@ jQuery(document).ready(function($) {
 			});
     	}
 	);
+
+    var con_apply_setting_value = $('#alg_wc_custom_order_numbers_settings_to_apply').val();
+    if ( con_apply_setting_value == 'new_order' || con_apply_setting_value == 'all_orders' ) {
+
+        $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]').closest('tr').hide();
+        $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]').closest('tr').hide();
+    }
+    if ( con_apply_setting_value == 'order_id' ) {
+        $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]').closest('tr').hide();
+    }
+    if ( con_apply_setting_value == 'date' ) {
+        $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]').closest('tr').hide();
+    }
+    $('#alg_wc_custom_order_numbers_settings_to_apply').change( function(){
+        var con_apply_setting_value = $('#alg_wc_custom_order_numbers_settings_to_apply').val();
+        if ( con_apply_setting_value == 'order_id' ) {
+            $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]').closest('tr').show();
+        } else {
+            $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_order_id]').closest('tr').hide();
+        }
+        if ( con_apply_setting_value == 'date' ) {
+            $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]').closest('tr').show();
+        } else {
+            $('[id=alg_wc_custom_order_numbers_settings_to_apply_from_date]').closest('tr').hide();
+        }
+    });
+
+    var today = new Date();
+    $('#alg_wc_custom_order_numbers_settings_to_apply_from_date').datepicker({
+        format: 'mm-dd-yyyy',
+        autoclose:true,
+        endDate: "today",
+        maxDate: today
+    }).on('changeDate', function (ev) {
+            $(this).datepicker('hide');
+        });
+    $('#alg_wc_custom_order_numbers_settings_to_apply_from_date').keyup(function () {
+        if (this.value.match(/[^0-9]/g)) {
+            this.value = this.value.replace(/[^0-9^-]/g, '');
+        }
+    });
 });


### PR DESCRIPTION
Added new setting 'Select orders to apply new settings to' which allow customers to select on which orders they want to apply setting changes. like new order, all orders, from order date and certain order number.

This commit need to be test with / without HPOS.