### PR TITLE
Lock row for update to prevent duplicate sequential order numbers

### DIFF
--- a/includes/class-alg-wc-custom-order-numbers-core.php
+++ b/includes/class-alg-wc-custom-order-numbers-core.php
@@ -1123,7 +1123,7 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 					global $wpdb;
 					$wpdb->query( 'START TRANSACTION' ); //phpcs:ignore
 					$wp_options_table = $wpdb->prefix . 'options';
-					$result_select    = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM `' . $wpdb->prefix . 'options` WHERE option_name = %s', 'alg_wc_custom_order_numbers_counter' ) ); //phpcs:ignore
+					$result_select    = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM `' . $wpdb->prefix . 'options` WHERE option_name = %s FOR UPDATE', 'alg_wc_custom_order_numbers_counter' ) ); //phpcs:ignore
 					if ( null !== $result_select ) {
 						$current_order_number     = $this->maybe_reset_sequential_counter( $result_select->option_value, $order_id );
 						$result_update            = $wpdb->update( // phpcs:ignore


### PR DESCRIPTION
I maintain a busy shop and it regularly generates duplicate order numbers when two people order at the same time. Upon investigation I found out that this plugin is already using transactions to prevent duplicate order numbers, which however is ineffective without also locking the row until committing the transaction. This pull request adds the missing lock.