### PR TITLE
Fix the fatal error in migration

### DIFF
--- a/custom-order-numbers-for-woocommerce.php
+++ b/custom-order-numbers-for-woocommerce.php
@@ -38,8 +38,8 @@ if ( ! class_exists( 'Custom_Order_Numbers', false ) ) {
  *
  * @since  1.0
  */
-function CON() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+function CON_Lite() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 	return Custom_Order_Numbers::instance();
 }
 
-CON();
+CON_Lite();

--- a/includes/class-files.php
+++ b/includes/class-files.php
@@ -28,8 +28,8 @@ class Files {
 	 */
 	public static function include_files() {
 
-        CON()::include_file( 'api/class-admin-api.php' );
-        CON()::include_file( 'api/class-admin-api-settings.php' );
+        CON_Lite()::include_file( 'api/class-admin-api.php' );
+        CON_Lite()::include_file( 'api/class-admin-api-settings.php' );
 
         $tyche_files = array(
             'class-tyche-con-tracking.php',
@@ -38,20 +38,20 @@ class Files {
 
         foreach ( $tyche_files as $tyche_file ) {
             if ( file_exists( CON_PLUGIN_DIR_PATH . '/includes/' . $tyche_file ) ) {
-                CON()::include_file( $tyche_file );
+                CON_Lite()::include_file( $tyche_file );
             }
         }
 
-		CON()::include_file( 'class-functions.php' );
+		CON_Lite()::include_file( 'class-functions.php' );
 
-		CON()::include_file( 'admin/class-admin.php' );
+		CON_Lite()::include_file( 'admin/class-admin.php' );
 
 		// Scripts.
-		CON()::include_file( 'admin/class-admin-scripts.php' );
+		CON_Lite()::include_file( 'admin/class-admin-scripts.php' );
 		new \Tyche\CON\Admin\Admin_Scripts();
 
 		//Frontend
-		CON()::include_file( 'class-core.php' );
+		CON_Lite()::include_file( 'class-core.php' );
 	}
 
 	/**

--- a/src/components/optionsTable.js
+++ b/src/components/optionsTable.js
@@ -113,8 +113,25 @@ const OptionsTable = ({
                     }
                 </CardBody>
             </Card>
-            <HStack> 
-                <Button className='con-button-add-option' onClick={() => append( defaultValue )} disabled={ 'prefix_suffix_rules' === id ? true : false }>{__('+ Add Rule', 'custom-order-numbers-for-woocommerce')}</Button>
+            <HStack alignment="left">
+                { 'prefix_suffix_rules' === id ? (
+                    <Tooltip
+                        text={
+                            <span>
+                                { __( 'Upgrade to Pro to add more rules.', 'custom-order-numbers-for-woocommerce' ) }{ ' ' }
+                                <a href={ upgradeUrl } target="_blank" rel="noopener noreferrer" style={{ color: '#a8c4ff' }}>
+                                    { __( 'Upgrade now', 'custom-order-numbers-for-woocommerce' ) }
+                                </a>
+                            </span>
+                        }
+                    >
+                        <span style={{ display: 'inline-block', cursor: 'not-allowed' }}>
+                            <Button className='con-button-add-option' disabled style={{ pointerEvents: 'none' }}>{ __( '+ Add Rule', 'custom-order-numbers-for-woocommerce' ) }</Button>
+                        </span>
+                    </Tooltip>
+                ) : (
+                    <Button className='con-button-add-option' onClick={() => append( defaultValue )}>{ __( '+ Add Rule', 'custom-order-numbers-for-woocommerce' ) }</Button>
+                ) }
             </HStack>
         </>
     );

--- a/src/screens/conditionalRules.js
+++ b/src/screens/conditionalRules.js
@@ -133,7 +133,22 @@ function ConditionalRules( { noticeOperations, noticeUI, parentRef, settingsData
     const rulesDefaults = {
         enable_prefix_suffix: false,
         custom_order_numbers_template: '{prefix}{date_prefix}{number}{suffix}{date_suffix}',
-        prefix_suffix_rules: [],
+        prefix_suffix_rules: [ 
+            {
+                condition_type: 'custom',
+                condition_value: '',
+                prefix: '',
+                suffix: '',
+                sequential: false
+            },
+            {
+                condition_type: 'date',
+                condition_value: '',
+                prefix: '',
+                suffix: '',
+                sequential: false
+            }
+        ],
     };
 
     const resetSettings = async () => {
@@ -175,14 +190,6 @@ function ConditionalRules( { noticeOperations, noticeUI, parentRef, settingsData
         if (nextCursorPosition !== null) {
             cursorPositionRef.current = nextCursorPosition;
         }
-    };
-
-    const handlePlaceholderInsert = (placeholder) => {
-        const currentValue = orderTemplate || '';
-        const insertAt = Math.max(0, cursorPositionRef.current);
-        const newValue = currentValue.substring(0, insertAt) + placeholder + currentValue.substring(insertAt);
-
-        handleTemplateChange(newValue, insertAt + placeholder.length);
     };
 
     const handleSettingsUpdate = async (data) => {


### PR DESCRIPTION
Fix #161 - The Custom & Date options were being removed on Reset settings. Added these options as default and added a tooltip to upgrade to pro on 'Add Rule' button.

Fix #163 - Fixed the fatal error displayed on lite to pro migration.