### PR TITLE
Renumber orders resulted in fatal error for large no of orders

### DIFF
--- a/includes/api/class-admin-api-settings.php
+++ b/includes/api/class-admin-api-settings.php
@@ -92,32 +92,45 @@ class Admin_API_Settings extends Admin_API {
 	}
 
 	/**
-	 * Returns whether a rules batch processing job is still pending or running.
+	 * Returns whether a rules batch processing job or renumeration job is still pending or running.
 	 */
 	public static function get_batch_status() {
-		$in_progress = false;
+		$in_progress           = false;
+		$renumerate_in_progress = false;
 
 		if ( function_exists( 'as_get_scheduled_actions' ) ) {
-			$pending = as_get_scheduled_actions(
-				array(
-					'hook'     => 'con_process_rules_batch',
-					'status'   => \ActionScheduler_Store::STATUS_PENDING,
-					'per_page' => 1,
-				),
-				'ids'
-			);
-			$running = as_get_scheduled_actions(
-				array(
-					'hook'     => 'con_process_rules_batch',
-					'status'   => \ActionScheduler_Store::STATUS_RUNNING,
-					'per_page' => 1,
-				),
-				'ids'
-			);
-			$in_progress = ! empty( $pending ) || ! empty( $running );
+			foreach ( array( 'con_process_rules_batch', 'con_renumerate_batch' ) as $hook ) {
+				$pending = as_get_scheduled_actions(
+					array(
+						'hook'     => $hook,
+						'status'   => \ActionScheduler_Store::STATUS_PENDING,
+						'per_page' => 1,
+					),
+					'ids'
+				);
+				$running = as_get_scheduled_actions(
+					array(
+						'hook'     => $hook,
+						'status'   => \ActionScheduler_Store::STATUS_RUNNING,
+						'per_page' => 1,
+					),
+					'ids'
+				);
+				$hook_active = ! empty( $pending ) || ! empty( $running );
+				if ( 'con_renumerate_batch' === $hook ) {
+					$renumerate_in_progress = $hook_active;
+				} else {
+					$in_progress = $hook_active;
+				}
+			}
 		}
 
-		return self::return_response( array( 'in_progress' => $in_progress ) );
+		return self::return_response(
+			array(
+				'in_progress'            => $in_progress,
+				'renumerate_in_progress' => $renumerate_in_progress,
+			)
+		);
 	}
 
 	/**
@@ -152,6 +165,10 @@ class Admin_API_Settings extends Admin_API {
 
 		if ( is_null( $result ) ) {
 			return self::return_response( array( 'error' => 'Renumeration could not be triggered. Ensure the plugin is enabled.' ) );
+		}
+
+		if ( isset( $result['scheduled'] ) && $result['scheduled'] ) {
+			return self::return_response( array( 'scheduled' => true ) );
 		}
 
 		return self::return_response(

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -73,19 +73,48 @@ if ( ! class_exists( 'Tyche\CON\Core' ) ) :
 			}
 
 			add_action( 'con_process_rules_batch', array( $this, 'process_rules_batch' ) );
+			add_action( 'con_renumerate_batch', array( $this, 'process_renumerate_batch' ) );
 			add_action( 'admin_notices', array( $this, 'maybe_show_batch_notice' ) );
+			add_action( 'wp_ajax_con_dismiss_renumerate_complete', array( $this, 'dismiss_renumerate_complete' ) );
+		}
+
+		/**
+		 * AJAX handler — deletes the renumeration complete transient when the notice is dismissed.
+		 */
+		public function dismiss_renumerate_complete() {
+			check_ajax_referer( 'con_dismiss_renumerate_complete', 'nonce' );
+			if ( current_user_can( 'manage_options' ) || current_user_can( 'manage_woocommerce' ) ) {
+				delete_transient( 'con_renumerate_complete' );
+			}
+			wp_die();
 		}
 
 		/**
 		 * Display an admin notice while the rules batch is processing.
 		 */
 		public function maybe_show_batch_notice() {
-			if ( ! get_transient( 'con_rules_batch_in_progress' ) ) {
-				return;
+			if ( get_transient( 'con_renumerate_complete' ) ) {
+				echo '<div class="notice notice-success is-dismissible" id="con-renumerate-complete-notice"><p>'
+					. esc_html__( 'Renumeration complete. All order numbers have been updated.', 'custom-order-numbers-for-woocommerce' )
+					. '</p></div>';
+				printf(
+					'<script>
+						jQuery( document ).on( "click", "#con-renumerate-complete-notice .notice-dismiss", function() {
+							jQuery.post( ajaxurl, { action: "con_dismiss_renumerate_complete", nonce: "%s" } );
+						} );
+					</script>',
+					esc_js( wp_create_nonce( 'con_dismiss_renumerate_complete' ) )
+				);
 			}
-			echo '<div id="con-batch-notice" class="notice notice-info"><p>'
-				. esc_html__( 'Custom order numbers are being updated in the background.', 'custom-order-numbers-for-woocommerce' )
-				. '</p></div>';
+			if ( get_transient( 'con_renumerate_batch_in_progress' ) ) {
+				echo '<div id="con-batch-notice" class="notice notice-info"><p>'
+					. esc_html__( 'Custom order numbers are being renumbered in the background.', 'custom-order-numbers-for-woocommerce' )
+					. '</p></div>';
+			} elseif ( get_transient( 'con_rules_batch_in_progress' ) ) {
+				echo '<div id="con-batch-notice" class="notice notice-info"><p>'
+					. esc_html__( 'Custom order numbers are being updated in the background.', 'custom-order-numbers-for-woocommerce' )
+					. '</p></div>';
+			}
 		}
 
 		/**
@@ -269,63 +298,78 @@ if ( ! class_exists( 'Tyche\CON\Core' ) ) :
 
 		/**
 		 * Renumerate orders function.
+		 * Schedules async batch processing via Action Scheduler to avoid memory exhaustion on large stores.
 		 *
-		 * @version 1.1.2
+		 * @version 1.2.3
 		 * @since   1.0.0
 		 */
 		public function renumerate_orders() {
 			if ( 'sequential' === CON_Functions::get_setting( 'counter_type', 'sequential' ) && 'no' != CON_Functions::get_setting( 'counter_reset_enabled', 'no' ) ) { // phpcs:ignore
 				update_option( 'alg_wc_custom_order_numbers_counter_previous_order_date', 0 );
 			}
-			$total_renumerated    = 0;
-			$last_renumerated     = 0;
-			$offset               = 0;
-			$block_size           = 512;
+
+			as_unschedule_all_actions( 'con_renumerate_batch' );
+			set_transient( 'con_renumerate_batch_in_progress', true, HOUR_IN_SECONDS * 2 );
+			as_schedule_single_action( time(), 'con_renumerate_batch', array( 1 ), 'con' );
+
+			return array( 'scheduled' => true );
+		}
+
+		/**
+		 * Process a single batch of orders during renumeration.
+		 * Scheduled via Action Scheduler; reschedules itself until all orders are processed.
+		 *
+		 * @param int $page 1-based page number.
+		 */
+		public function process_renumerate_batch( $page ) {
+			$batch_size           = 100;
 			$subscriptions_active = in_array( 'woocommerce-subscriptions/woocommerce-subscriptions.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true );
 			$order_types          = $subscriptions_active ? array( 'shop_order', 'shop_subscription' ) : array( 'shop_order' );
-			while ( true ) {
-				if ( $this->con_wc_hpos_enabled() ) {
-					$args        = array(
-						'type'           => $order_types,
-						'status'         => 'any',
-						'posts_per_page' => $block_size,
-						'orderby'        => 'date',
-						'order'          => 'ASC',
-						'offset'         => $offset,
-					);
-					$loop_orders = wc_get_orders( $args );
-					if ( count( $loop_orders ) <= 0 ) {
-						break;
-					}
-					foreach ( $loop_orders as $order_ids ) {
-						$order_id         = $order_ids->get_id();
-						$last_renumerated = $this->add_order_number_meta( $order_id, true );
-						++$total_renumerated;
-					}
-					$offset += $block_size;
-				} else {
-					$args = array(
+			$order_ids            = array();
+
+			if ( CON_Functions::con_wc_hpos_enabled() ) {
+				$order_ids = wc_get_orders(
+					array(
+						'type'    => $order_types,
+						'status'  => 'any',
+						'limit'   => $batch_size,
+						'page'    => $page,
+						'orderby' => 'date',
+						'order'   => 'ASC',
+						'return'  => 'ids',
+					)
+				);
+			} else {
+				$query = new \WP_Query(
+					array(
 						'post_type'      => $order_types,
 						'post_status'    => 'any',
-						'posts_per_page' => $block_size,
+						'posts_per_page' => $batch_size,
+						'paged'          => $page,
 						'orderby'        => 'date',
 						'order'          => 'ASC',
-						'offset'         => $offset,
 						'fields'         => 'ids',
-					);
-					$loop = new \WP_Query( $args );
-					if ( ! $loop->have_posts() ) {
-						break;
-					}
-					foreach ( $loop->posts as $order_id ) {
-						$last_renumerated = $this->add_order_number_meta( $order_id, true );
-						++$total_renumerated;
-					}
-					$offset += $block_size;
-				}
+					)
+				);
+				$order_ids = $query->posts;
 			}
 
-			return array( $total_renumerated, $last_renumerated );
+			if ( empty( $order_ids ) ) {
+				delete_transient( 'con_renumerate_batch_in_progress' );
+				set_transient( 'con_renumerate_complete', true, DAY_IN_SECONDS );
+				return;
+			}
+
+			foreach ( $order_ids as $order_id ) {
+				$this->add_order_number_meta( $order_id, true );
+			}
+
+			if ( count( $order_ids ) === $batch_size ) {
+				as_schedule_single_action( time(), 'con_renumerate_batch', array( $page + 1 ), 'con' );
+			} else {
+				delete_transient( 'con_renumerate_batch_in_progress' );
+				set_transient( 'con_renumerate_complete', true, DAY_IN_SECONDS );
+			}
 		}
 
 		/**

--- a/languages/custom-order-numbers-for-woocommerce.po
+++ b/languages/custom-order-numbers-for-woocommerce.po
@@ -24,123 +24,123 @@ msgid "General"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:291
+#: src/screens/general.js:293
 msgid "Custom Order Numbers Options"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:292
+#: src/screens/general.js:294
 msgid "Enable sequential order numbering, set custom number prefix, suffix and number width."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:298
+#: src/screens/general.js:300
 msgid "WooCommerce Custom Order Numbers"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:317
+#: src/screens/general.js:319
 msgid "Sequential"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:318
+#: src/screens/general.js:320
 msgid "Order ID"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:319
+#: src/screens/general.js:321
 msgid "Pseudorandom - crc32 Hash (max 10 digits)"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:367
+#: src/screens/general.js:369
 msgid "Disabled"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:368
+#: src/screens/general.js:370
 msgid "Daily"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:369
+#: src/screens/general.js:371
 msgid "Weekly"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:370
+#: src/screens/general.js:372
 msgid "Monthly"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:371
+#: src/screens/general.js:373
 msgid "Yearly"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:392
+#: src/screens/general.js:394
 msgid "Monday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:393
+#: src/screens/general.js:395
 msgid "Tuesday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:394
+#: src/screens/general.js:396
 msgid "Wednesday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:395
+#: src/screens/general.js:397
 msgid "Thursday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:396
+#: src/screens/general.js:398
 msgid "Friday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:397
+#: src/screens/general.js:399
 msgid "Saturday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:398
+#: src/screens/general.js:400
 msgid "Sunday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:447
+#: src/screens/general.js:449
 msgid "To all new orders only"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:448
+#: src/screens/general.js:450
 msgid "To orders from a certain order number"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:449
+#: src/screens/general.js:451
 msgid "To orders from a specific date"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:450
+#: src/screens/general.js:452
 msgid "To all orders"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:494
-#: src/screens/general.js:507
+#: src/screens/general.js:496
+#: src/screens/general.js:509
 msgid "Enable"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:75
+#: src/screens/renumerateOrders.js:135
 msgid "With the help of this tool, you can change the custom order numbers for all the existing orders in a sequence and will maintain the sequence for the upcoming orders also."
 msgstr ""
 
@@ -186,13 +186,13 @@ msgstr ""
 
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:447
-#: src/screens/general.js:609
+#: src/screens/general.js:611
 msgid "Reset Settings"
 msgstr ""
 
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:453
-#: src/screens/general.js:615
+#: src/screens/general.js:617
 msgid "Reset"
 msgstr ""
 
@@ -202,13 +202,13 @@ msgstr ""
 
 #: includes/tyche/components/plugin-tracking/class-con-data-tracking.php:51
 #: build/admin.js:1
-#: src/screens/general.js:591
+#: src/screens/general.js:593
 msgid "Reset Usage Tracking"
 msgstr ""
 
 #: includes/tyche/components/plugin-tracking/class-con-data-tracking.php:52
 #: build/admin.js:1
-#: src/screens/general.js:590
+#: src/screens/general.js:592
 msgid "This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data."
 msgstr ""
 
@@ -236,10 +236,10 @@ msgstr ""
 msgid "Guest"
 msgstr ""
 
-#: includes/class-core.php:87
+#: includes/class-core.php:115
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:42
-#: src/screens/general.js:40
+#: src/screens/general.js:42
 msgid "Custom order numbers are being updated in the background."
 msgstr ""
 
@@ -284,196 +284,196 @@ msgid "(no condition value needed)"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:268
+#: src/screens/general.js:270
 msgid "Tracking has been successfully reset."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:275
+#: src/screens/general.js:277
 msgid "Error resetting tracking."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:301
+#: src/screens/general.js:303
 msgid "Enable Custom Order Numbers"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:302
+#: src/screens/general.js:304
 msgid "Turn this on to start using custom order numbering for your store."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:311
+#: src/screens/general.js:313
 msgid "Order Numbers Counter"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:324
+#: src/screens/general.js:326
 msgid "Choose how order numbers are generated: Sequential (1, 2, 3…), Order ID, or Random (a unique scrambled number, max 10 digits)."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:333
+#: src/screens/general.js:335
 msgid "Include Characters"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:336
+#: src/screens/general.js:338
 msgid "Enable to include charaters in order number"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:346
+#: src/screens/general.js:348
 msgid "Next Order Number"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:349
+#: src/screens/general.js:351
 msgid "The next order placed will be assigned this number. To renumber existing orders, use the Renumber Orders tab."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:361
+#: src/screens/general.js:363
 msgid "Auto-Reset Order Count"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:377
+#: src/screens/general.js:379
 msgid "Automatically reset the order number counter at the start of each day, week, month, or year. Useful if you want numbers to restart periodically."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:386
+#: src/screens/general.js:388
 msgid "Weekly Counter Reset Day"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:403
+#: src/screens/general.js:405
 msgid "Select the day of the week on which the order number counter will automatically reset."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:412
+#: src/screens/general.js:414
 msgid "Reset Counter Value"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:415
+#: src/screens/general.js:417
 msgid "Counter value to reset to. This will be ignored if \"Auto-Reset Order Count\" option is set to \"Disabled\"."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:426
+#: src/screens/general.js:428
 msgid "Minimum Digits in Order Number"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:441
+#: src/screens/general.js:443
 msgid "Apply These Settings To"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:456
+#: src/screens/general.js:458
 msgid "Choose which orders should use your new numbering settings."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:464
+#: src/screens/general.js:466
 msgid "Starting Order ID"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:467
+#: src/screens/general.js:469
 msgid "New numbering settings will be applied to all orders from this order ID onwards."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:478
+#: src/screens/general.js:480
 msgid "Starting Order Date"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:481
+#: src/screens/general.js:483
 msgid "New numbering settings will be applied to all orders from this date onwards. Note : Only applies to past dates."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:491
+#: src/screens/general.js:493
 msgid "Order Tracking by Custom Number"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:497
+#: src/screens/general.js:499
 msgid "This will allow customers to track their orders using custom order numbers on the \"Track your order\" page. This page must be created using [woocommerce_order_tracking] shortcode."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:504
+#: src/screens/general.js:506
 msgid "Set Order Number Manually"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:508
+#: src/screens/general.js:510
 msgid "Adds an \"Order Number\" field on each order's edit page, so you can enter the number yourself. Requires the Order Number Format to be set to Sequential."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:518
+#: src/screens/general.js:520
 msgid "Hide Renumber Orders tab for User Roles"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:539
-#: src/screens/general.js:569
+#: src/screens/general.js:541
+#: src/screens/general.js:571
 msgid "Search for a user role..."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:540
+#: src/screens/general.js:542
 msgid "Hide \"Renumber Orders\" admin menu for selected user roles. All user roles are listed here - even those which do not see the menu by default."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:548
+#: src/screens/general.js:550
 msgid "Hide Plugin Settings for User Roles"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:570
+#: src/screens/general.js:572
 msgid "Hide \"Custom Order Numbers\" admin settings tab for selected user roles. Tab can not be hidden for administrators. All user roles are listed here - even those which do not see the tab by default."
 msgstr ""
 
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:442
-#: src/screens/general.js:603
+#: src/screens/general.js:605
 msgid "Save Changes"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:607
+#: src/screens/general.js:609
 msgid "Reset plugin settings to default values."
 msgstr ""
 
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:452
-#: src/screens/general.js:614
+#: src/screens/general.js:616
 msgid "Cancel"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:246
+#: src/screens/general.js:248
 msgid "Settings have been successfully reset to default values."
 msgstr ""
 
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:178
-#: src/screens/general.js:253
+#: src/screens/general.js:255
 msgid "Error resetting the settings."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:619
+#: src/screens/general.js:621
 msgid "Are you sure you want to reset all settings to their default values? This will also clear all prefix/suffix rules."
 msgstr ""
 
@@ -533,34 +533,35 @@ msgid "Are you sure you want to reset all rules settings to their default values
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:36
+#: src/screens/renumerateOrders.js:96
+#: src/screens/renumerateOrders.js:105
 msgid "Error renumbering orders."
 msgstr ""
 
 #: build/admin.js:1
 #: src/app.js:74
-#: src/screens/renumerateOrders.js:60
-#: src/screens/renumerateOrders.js:83
+#: src/screens/renumerateOrders.js:120
+#: src/screens/renumerateOrders.js:149
 msgid "Renumber Orders"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:62
+#: src/screens/renumerateOrders.js:122
 msgid "Use this tool to reassign order numbers to all your existing orders in sequence."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:69
+#: src/screens/renumerateOrders.js:129
 msgid "Important:"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:70
+#: src/screens/renumerateOrders.js:130
 msgid "Before proceeding, please ensure you have created a complete backup of your database. This tool will modify existing order numbers and cannot be easily undone."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:77
+#: src/screens/renumerateOrders.js:136
 msgid "The starting order number will always be 1, and all orders will be numbered sequentially from there."
 msgstr ""
 
@@ -761,12 +762,7 @@ msgid "Unlock All"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:429
-msgid "Pad order numbers with leading zeros to reach this length. For example, set to 5 to show \"00001\" instead of \"1\". Set to 0 to disable padding. Upgrade to Pro"
-msgstr ""
-
-#: build/admin.js:1
-#: src/screens/general.js:580
+#: src/screens/general.js:582
 msgid "Usage Data"
 msgstr ""
 
@@ -823,4 +819,27 @@ msgstr ""
 #: build/admin.js:1
 #: src/components/optionsTable.js:123
 msgid "Upgrade now"
+msgstr ""
+
+#: build/admin.js:1
+#: src/screens/general.js:431
+msgid "Pad order numbers with leading zeros to reach this length. For example, set to 5 to show \"00001\" instead of \"1\". Set to 0 to disable padding."
+msgstr ""
+
+#: build/admin.js:1
+#: src/screens/general.js:431
+#: src/screens/general.js:510
+msgid "Upgrade to Pro"
+msgstr ""
+
+#: includes/class-core.php:98
+#: build/admin.js:1
+#: src/screens/renumerateOrders.js:54
+msgid "Renumeration complete. All order numbers have been updated."
+msgstr ""
+
+#: includes/class-core.php:111
+#: build/admin.js:1
+#: src/screens/renumerateOrders.js:84
+msgid "Custom order numbers are being renumbered in the background."
 msgstr ""

--- a/languages/custom-order-numbers-for-woocommerce.pot
+++ b/languages/custom-order-numbers-for-woocommerce.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-18T08:29:18+00:00\n"
+"POT-Creation-Date: 2026-06-22T06:42:53+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: custom-order-numbers-for-woocommerce\n"
@@ -45,10 +45,22 @@ msgstr ""
 msgid "Guest"
 msgstr ""
 
-#: includes/class-core.php:87
+#: includes/class-core.php:98
+#: build/admin.js:1
+#: src/screens/renumerateOrders.js:54
+msgid "Renumeration complete. All order numbers have been updated."
+msgstr ""
+
+#: includes/class-core.php:111
+#: build/admin.js:1
+#: src/screens/renumerateOrders.js:84
+msgid "Custom order numbers are being renumbered in the background."
+msgstr ""
+
+#: includes/class-core.php:115
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:42
-#: src/screens/general.js:40
+#: src/screens/general.js:42
 msgid "Custom order numbers are being updated in the background."
 msgstr ""
 
@@ -85,13 +97,13 @@ msgstr ""
 
 #: includes/tyche/components/plugin-tracking/class-con-data-tracking.php:51
 #: build/admin.js:1
-#: src/screens/general.js:591
+#: src/screens/general.js:593
 msgid "Reset Usage Tracking"
 msgstr ""
 
 #: includes/tyche/components/plugin-tracking/class-con-data-tracking.php:52
 #: build/admin.js:1
-#: src/screens/general.js:590
+#: src/screens/general.js:592
 msgid "This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data."
 msgstr ""
 
@@ -127,334 +139,340 @@ msgid "+ Add Rule"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:268
+#: src/screens/general.js:270
 msgid "Tracking has been successfully reset."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:275
+#: src/screens/general.js:277
 msgid "Error resetting tracking."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:291
+#: src/screens/general.js:293
 msgid "Custom Order Numbers Options"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:292
+#: src/screens/general.js:294
 msgid "Enable sequential order numbering, set custom number prefix, suffix and number width."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:298
+#: src/screens/general.js:300
 msgid "WooCommerce Custom Order Numbers"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:301
+#: src/screens/general.js:303
 msgid "Enable Custom Order Numbers"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:302
+#: src/screens/general.js:304
 msgid "Turn this on to start using custom order numbering for your store."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:311
+#: src/screens/general.js:313
 msgid "Order Numbers Counter"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:317
+#: src/screens/general.js:319
 msgid "Sequential"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:318
+#: src/screens/general.js:320
 msgid "Order ID"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:319
+#: src/screens/general.js:321
 msgid "Pseudorandom - crc32 Hash (max 10 digits)"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:324
+#: src/screens/general.js:326
 msgid "Choose how order numbers are generated: Sequential (1, 2, 3…), Order ID, or Random (a unique scrambled number, max 10 digits)."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:333
+#: src/screens/general.js:335
 msgid "Include Characters"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:336
+#: src/screens/general.js:338
 msgid "Enable to include charaters in order number"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:346
+#: src/screens/general.js:348
 msgid "Next Order Number"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:349
+#: src/screens/general.js:351
 msgid "The next order placed will be assigned this number. To renumber existing orders, use the Renumber Orders tab."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:361
+#: src/screens/general.js:363
 msgid "Auto-Reset Order Count"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:367
+#: src/screens/general.js:369
 msgid "Disabled"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:368
+#: src/screens/general.js:370
 msgid "Daily"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:369
+#: src/screens/general.js:371
 msgid "Weekly"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:370
+#: src/screens/general.js:372
 msgid "Monthly"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:371
+#: src/screens/general.js:373
 msgid "Yearly"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:377
+#: src/screens/general.js:379
 msgid "Automatically reset the order number counter at the start of each day, week, month, or year. Useful if you want numbers to restart periodically."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:386
+#: src/screens/general.js:388
 msgid "Weekly Counter Reset Day"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:392
+#: src/screens/general.js:394
 msgid "Monday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:393
+#: src/screens/general.js:395
 msgid "Tuesday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:394
+#: src/screens/general.js:396
 msgid "Wednesday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:395
+#: src/screens/general.js:397
 msgid "Thursday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:396
+#: src/screens/general.js:398
 msgid "Friday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:397
+#: src/screens/general.js:399
 msgid "Saturday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:398
+#: src/screens/general.js:400
 msgid "Sunday"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:403
+#: src/screens/general.js:405
 msgid "Select the day of the week on which the order number counter will automatically reset."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:412
+#: src/screens/general.js:414
 msgid "Reset Counter Value"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:415
+#: src/screens/general.js:417
 msgid "Counter value to reset to. This will be ignored if \"Auto-Reset Order Count\" option is set to \"Disabled\"."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:426
+#: src/screens/general.js:428
 msgid "Minimum Digits in Order Number"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:429
-msgid "Pad order numbers with leading zeros to reach this length. For example, set to 5 to show \"00001\" instead of \"1\". Set to 0 to disable padding. Upgrade to Pro"
+#: src/screens/general.js:431
+msgid "Pad order numbers with leading zeros to reach this length. For example, set to 5 to show \"00001\" instead of \"1\". Set to 0 to disable padding."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:441
+#: src/screens/general.js:431
+#: src/screens/general.js:510
+msgid "Upgrade to Pro"
+msgstr ""
+
+#: build/admin.js:1
+#: src/screens/general.js:443
 msgid "Apply These Settings To"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:447
+#: src/screens/general.js:449
 msgid "To all new orders only"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:448
+#: src/screens/general.js:450
 msgid "To orders from a certain order number"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:449
+#: src/screens/general.js:451
 msgid "To orders from a specific date"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:450
+#: src/screens/general.js:452
 msgid "To all orders"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:456
+#: src/screens/general.js:458
 msgid "Choose which orders should use your new numbering settings."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:464
+#: src/screens/general.js:466
 msgid "Starting Order ID"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:467
+#: src/screens/general.js:469
 msgid "New numbering settings will be applied to all orders from this order ID onwards."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:478
+#: src/screens/general.js:480
 msgid "Starting Order Date"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:481
+#: src/screens/general.js:483
 msgid "New numbering settings will be applied to all orders from this date onwards. Note : Only applies to past dates."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:491
+#: src/screens/general.js:493
 msgid "Order Tracking by Custom Number"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:494
-#: src/screens/general.js:507
+#: src/screens/general.js:496
+#: src/screens/general.js:509
 msgid "Enable"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:497
+#: src/screens/general.js:499
 msgid "This will allow customers to track their orders using custom order numbers on the \"Track your order\" page. This page must be created using [woocommerce_order_tracking] shortcode."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:504
+#: src/screens/general.js:506
 msgid "Set Order Number Manually"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:508
+#: src/screens/general.js:510
 msgid "Adds an \"Order Number\" field on each order's edit page, so you can enter the number yourself. Requires the Order Number Format to be set to Sequential."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:518
+#: src/screens/general.js:520
 msgid "Hide Renumber Orders tab for User Roles"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:539
-#: src/screens/general.js:569
+#: src/screens/general.js:541
+#: src/screens/general.js:571
 msgid "Search for a user role..."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:540
+#: src/screens/general.js:542
 msgid "Hide \"Renumber Orders\" admin menu for selected user roles. All user roles are listed here - even those which do not see the menu by default."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:548
+#: src/screens/general.js:550
 msgid "Hide Plugin Settings for User Roles"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:570
+#: src/screens/general.js:572
 msgid "Hide \"Custom Order Numbers\" admin settings tab for selected user roles. Tab can not be hidden for administrators. All user roles are listed here - even those which do not see the tab by default."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:580
+#: src/screens/general.js:582
 msgid "Usage Data"
 msgstr ""
 
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:442
-#: src/screens/general.js:603
+#: src/screens/general.js:605
 msgid "Save Changes"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:607
+#: src/screens/general.js:609
 msgid "Reset plugin settings to default values."
 msgstr ""
 
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:447
-#: src/screens/general.js:609
+#: src/screens/general.js:611
 msgid "Reset Settings"
 msgstr ""
 
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:452
-#: src/screens/general.js:614
+#: src/screens/general.js:616
 msgid "Cancel"
 msgstr ""
 
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:453
-#: src/screens/general.js:615
+#: src/screens/general.js:617
 msgid "Reset"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:246
+#: src/screens/general.js:248
 msgid "Settings have been successfully reset to default values."
 msgstr ""
 
 #: build/admin.js:1
 #: src/screens/conditionalRules.js:178
-#: src/screens/general.js:253
+#: src/screens/general.js:255
 msgid "Error resetting the settings."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/general.js:619
+#: src/screens/general.js:621
 msgid "Are you sure you want to reset all settings to their default values? This will also clear all prefix/suffix rules."
 msgstr ""
 
@@ -605,39 +623,40 @@ msgid "Are you sure you want to reset all rules settings to their default values
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:36
+#: src/screens/renumerateOrders.js:96
+#: src/screens/renumerateOrders.js:105
 msgid "Error renumbering orders."
 msgstr ""
 
 #: build/admin.js:1
 #: src/app.js:74
-#: src/screens/renumerateOrders.js:60
-#: src/screens/renumerateOrders.js:83
+#: src/screens/renumerateOrders.js:120
+#: src/screens/renumerateOrders.js:149
 msgid "Renumber Orders"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:62
+#: src/screens/renumerateOrders.js:122
 msgid "Use this tool to reassign order numbers to all your existing orders in sequence."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:69
+#: src/screens/renumerateOrders.js:129
 msgid "Important:"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:70
+#: src/screens/renumerateOrders.js:130
 msgid "Before proceeding, please ensure you have created a complete backup of your database. This tool will modify existing order numbers and cannot be easily undone."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:75
+#: src/screens/renumerateOrders.js:135
 msgid "With the help of this tool, you can change the custom order numbers for all the existing orders in a sequence and will maintain the sequence for the upcoming orders also."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:77
+#: src/screens/renumerateOrders.js:136
 msgid "The starting order number will always be 1, and all orders will be numbered sequentially from there."
 msgstr ""
 

--- a/src/screens/renumerateOrders.js
+++ b/src/screens/renumerateOrders.js
@@ -1,106 +1,171 @@
+import { useState, useEffect } from "@wordpress/element";
 import { useForm } from "react-hook-form";
-import { 
-    Card, 
-    CardHeader, 
-    CardBody, 
-    __experimentalText as Text, 
+import {
+    Card,
+    CardHeader,
+    CardBody,
+    __experimentalText as Text,
     __experimentalVStack as VStack,
     __experimentalHStack as HStack,
-    __experimentalHeading as Heading, 
+    __experimentalHeading as Heading,
     Button,
     Notice,
     withNotices
 } from "@wordpress/components";
 import { __ } from "@wordpress/i18n";
-import { renumerateOrders } from "../data/api";
+import { renumerateOrders, getBatchStatus } from "../data/api";
 
-function RenumerateOrders( {noticeOperations, noticeUI } ) {
+function RenumerateOrders( { noticeOperations, noticeUI } ) {
 
     const { handleSubmit, formState: { isSubmitting } } = useForm({
         defaultValues: {},
     });
 
+    const [ isRenumerating, setIsRenumerating ] = useState( false );
+
+    // Auto-dismiss notices after 4 seconds.
+    useEffect( () => {
+        if ( noticeUI ) {
+            const timer = setTimeout( () => {
+                noticeOperations.removeAllNotices();
+            }, 4000 );
+            return () => clearTimeout( timer );
+        }
+    }, [ noticeUI ] );
+
+    // Poll batch-status while renumeration is running; show complete notice when done.
+    useEffect( () => {
+        if ( ! isRenumerating ) return;
+
+        let timeoutId;
+        let cancelled = false;
+        let delay = 3000;
+        const maxDelay = 30000;
+
+        const poll = async () => {
+            try {
+                const status = await getBatchStatus();
+                if ( cancelled ) return;
+                if ( ! status?.renumerate_in_progress ) {
+                    setIsRenumerating( false );
+                    noticeOperations.removeAllNotices();
+                    noticeOperations.createNotice( {
+                        status: 'success',
+                        content: __( 'Renumeration complete. All order numbers have been updated.', 'custom-order-numbers-for-woocommerce' ),
+                    } );
+                    return;
+                }
+            } catch {
+                if ( ! cancelled ) {
+                    setIsRenumerating( false );
+                }
+                return;
+            }
+            delay = Math.min( delay * 2, maxDelay );
+            timeoutId = setTimeout( poll, delay );
+        };
+
+        timeoutId = setTimeout( poll, delay );
+
+        return () => {
+            cancelled = true;
+            clearTimeout( timeoutId );
+        };
+    }, [ isRenumerating ] );
+
     const onSubmit = async () => {
         try {
             const response = await renumerateOrders();
-            console.log( response );
             noticeOperations.removeAllNotices();
-            noticeOperations.createNotice({
-                status: 'success',
-                content: __( `Renumeration complete. ${response.total_renumerated} order(s) updated.`, 'custom-order-numbers-for-woocommerce' ),
-            });
+            if ( response.scheduled ) {
+                setIsRenumerating( true );
+                noticeOperations.createNotice( {
+                    status: 'info',
+                    content: __( 'Custom order numbers are being renumbered in the background.', 'custom-order-numbers-for-woocommerce' ),
+                } );
+            } else {
+                noticeOperations.createNotice( {
+                    status: 'success',
+                    content: __( `Renumeration complete. ${ response.total_renumerated } order(s) updated.`, 'custom-order-numbers-for-woocommerce' ),
+                } );
+            }
         } catch ( error ) {
             noticeOperations.removeAllNotices();
-            noticeOperations.createNotice({
+            noticeOperations.createNotice( {
                 status: 'error',
                 content: error?.message || __( 'Error renumbering orders.', 'custom-order-numbers-for-woocommerce' ),
-            });
+            } );
         }
     };
 
     const onError = () => {
         noticeOperations.removeAllNotices();
-        noticeOperations.createNotice({
+        noticeOperations.createNotice( {
             status: 'error',
-            content: 'Error saving the settings.',
-        });
+            content: __( 'Error renumbering orders.', 'custom-order-numbers-for-woocommerce' ),
+        } );
     };
 
     return (
-        <VStack style={{margin: '30px'}}>
-             <div style={{ position: 'fixed', bottom: '20px', right: '20px', zIndex: 9999, maxWidth: '400px' }}>
-                 {noticeUI}
-             </div>
-             <form onSubmit={handleSubmit(onSubmit, onError)}>
-                 <VStack className={'con_setting_section'} spacing={10}>
- 
+        <VStack style={ { margin: '30px' } }>
+            <div style={ { position: 'fixed', bottom: '20px', right: '20px', zIndex: 9999, maxWidth: '400px' } }>
+                { noticeUI }
+            </div>
+            <form onSubmit={ handleSubmit( onSubmit, onError ) }>
+                <VStack className={ 'con_setting_section' } spacing={ 10 }>
+
                     <Card className="pif-field-builder con-renumerate-card">
                         <CardHeader>
                             <VStack spacing={ 2 }>
                                 <Heading level={ 4 }>{ __( 'Renumber Orders', 'custom-order-numbers-for-woocommerce' ) }</Heading>
-                                    <Text className="components-text">
-                                        { __( 'Use this tool to reassign order numbers to all your existing orders in sequence.', 'custom-order-numbers-for-woocommerce' ) }
-                                    </Text>
+                                <Text className="components-text">
+                                    { __( 'Use this tool to reassign order numbers to all your existing orders in sequence.', 'custom-order-numbers-for-woocommerce' ) }
+                                </Text>
                             </VStack>
                         </CardHeader>
                         <CardBody className="con-renumerate-content">
-                            <VStack style={{ marginBottom:'20px' }}>
-                                <Notice className="con-renumerate-warning" status="warning" isDismissible={false}>
+                            <VStack style={ { marginBottom: '20px' } }>
+                                <Notice className="con-renumerate-warning" status="warning" isDismissible={ false }>
                                     <strong>{ __( 'Important:', 'custom-order-numbers-for-woocommerce' ) }</strong>{ ' ' }
                                     { __( 'Before proceeding, please ensure you have created a complete backup of your database. This tool will modify existing order numbers and cannot be easily undone.', 'custom-order-numbers-for-woocommerce' ) }
                                 </Notice>
                             </VStack>
 
-                            <VStack style={{ marginBottom:'20px'}}>
-                                <Text isBlock={true}>{ __( 'With the help of this tool, you can change the custom order numbers for all the existing orders in a sequence and will maintain the sequence for the upcoming orders also.', 'custom-order-numbers-for-woocommerce' ) }</Text>
-
-                                <Text isBlock={true}>{ __('The starting order number will always be 1, and all orders will be numbered sequentially from there.', 'custom-order-numbers-for-woocommerce') }</Text>
+                            <VStack style={ { marginBottom: '20px' } }>
+                                <Text isBlock={ true }>{ __( 'With the help of this tool, you can change the custom order numbers for all the existing orders in a sequence and will maintain the sequence for the upcoming orders also.', 'custom-order-numbers-for-woocommerce' ) }</Text>
+                                <Text isBlock={ true }>{ __( 'The starting order number will always be 1, and all orders will be numbered sequentially from there.', 'custom-order-numbers-for-woocommerce' ) }</Text>
                             </VStack>
 
                             <div className="con-renumerate-divider"></div>
 
-                            <HStack spacing={3} expanded={false} justify="left">
-                                <Button className="con-renumerate-button" variant="primary" type="submit" isBusy={ isSubmitting } disabled={ isSubmitting }>{__('Renumber Orders', 'custom-order-numbers-for-woocommerce')}</Button>
+                            <HStack spacing={ 3 } expanded={ false } justify="left">
+                                <Button
+                                    className="con-renumerate-button"
+                                    variant="primary"
+                                    type="submit"
+                                    isBusy={ isSubmitting || isRenumerating }
+                                    disabled={ isSubmitting || isRenumerating }
+                                >
+                                    { __( 'Renumber Orders', 'custom-order-numbers-for-woocommerce' ) }
+                                </Button>
                             </HStack>
-                        </CardBody> 
+                        </CardBody>
                     </Card>
- 
-                 </VStack>
-                 
-             </form>
-             <style>
-                     {`
-                     tr:not(:last-child) td{
-                         padding-bottom: 30px;
-                     }
-                     td:nth-child(2){
-                         padding-left: 30px;
-                     }
-                `}
-             </style>
- 
-         </VStack>
-     );
+
+                </VStack>
+            </form>
+            <style>
+                { `
+                    tr:not(:last-child) td {
+                        padding-bottom: 30px;
+                    }
+                    td:nth-child(2) {
+                        padding-left: 30px;
+                    }
+                ` }
+            </style>
+        </VStack>
+    );
 }
 
 export default withNotices( RenumerateOrders );


### PR DESCRIPTION
Problem                                                                     
Clicking Renumber Orders on stores with 1000+ orders caused a PHP fatal error: Allowed memory size of 134217728 bytes exhausted. The entire renumeration ran synchronously inside a single REST API request - loading full WooCommerce order objects in batches of 512, exhausting PHP's 128MB memory limit and timing out. 

Changes
1. renumerate_orders() now schedules async batch processing via Action Scheduler instead of running synchronously.                                
2. New process_renumerate_batch($page) method processes 100 orders per batch,  order objects are loaded one at a time, not in bulk.                                            
3. Sets con_renumerate_complete transient when the last batch finishes. maybe_show_batch_notice() shows a persistent dismissible admin notice on page load when con_renumerate_complete is set.                                
4. New dismiss_renumerate_complete() AJAX handler deletes the transient when the notice is dismissed — notice persists across page loads until explicitly closed. 

Fix #167 