### PR TITLE
Fix the issue with renumbering 1000 orders

### DIFF
--- a/includes/api/class-admin-api-settings.php
+++ b/includes/api/class-admin-api-settings.php
@@ -125,10 +125,17 @@ class Admin_API_Settings extends Admin_API {
 			}
 		}
 
+		$total_raw            = get_transient( 'con_renumerate_total_orders' );
+		$processed_raw        = get_transient( 'con_renumerate_processed_count' );
+		$renumerate_total     = false !== $total_raw ? (int) $total_raw : null;
+		$renumerate_processed = false !== $processed_raw ? (int) $processed_raw : 0;
+
 		return self::return_response(
 			array(
 				'in_progress'            => $in_progress,
 				'renumerate_in_progress' => $renumerate_in_progress,
+				'renumerate_total'       => $renumerate_total,
+				'renumerate_processed'   => $renumerate_processed,
 			)
 		);
 	}
@@ -168,7 +175,8 @@ class Admin_API_Settings extends Admin_API {
 		}
 
 		if ( isset( $result['scheduled'] ) && $result['scheduled'] ) {
-			return self::return_response( array( 'scheduled' => true ) );
+			$total = false !== get_transient( 'con_renumerate_total_orders' ) ? (int) get_transient( 'con_renumerate_total_orders' ) : null;
+			return self::return_response( array( 'scheduled' => true, 'total' => $total ) );
 		}
 
 		return self::return_response(

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -309,10 +309,45 @@ if ( ! class_exists( 'Tyche\CON\Core' ) ) :
 			}
 
 			as_unschedule_all_actions( 'con_renumerate_batch' );
+
+			$total = $this->get_total_order_count();
+			set_transient( 'con_renumerate_total_orders', $total, HOUR_IN_SECONDS * 2 );
+			delete_transient( 'con_renumerate_processed_count' );
+
 			set_transient( 'con_renumerate_batch_in_progress', true, HOUR_IN_SECONDS * 2 );
 			as_schedule_single_action( time(), 'con_renumerate_batch', array( 1 ), 'con' );
 
 			return array( 'scheduled' => true );
+		}
+
+		/**
+		 * Returns the total number of orders (and subscriptions if active) in the store.
+		 */
+		private function get_total_order_count() {
+			$subscriptions_active = in_array( 'woocommerce-subscriptions/woocommerce-subscriptions.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true );
+			$order_types          = $subscriptions_active ? array( 'shop_order', 'shop_subscription' ) : array( 'shop_order' );
+
+			if ( CON_Functions::con_wc_hpos_enabled() ) {
+				$result = wc_get_orders(
+					array(
+						'type'     => $order_types,
+						'status'   => 'any',
+						'limit'    => 1,
+						'paginate' => true,
+					)
+				);
+				return isset( $result->total ) ? (int) $result->total : 0;
+			} else {
+				$query = new \WP_Query(
+					array(
+						'post_type'      => $order_types,
+						'post_status'    => 'any',
+						'posts_per_page' => 1,
+						'fields'         => 'ids',
+					)
+				);
+				return (int) $query->found_posts;
+			}
 		}
 
 		/**
@@ -356,6 +391,8 @@ if ( ! class_exists( 'Tyche\CON\Core' ) ) :
 
 			if ( empty( $order_ids ) ) {
 				delete_transient( 'con_renumerate_batch_in_progress' );
+				delete_transient( 'con_renumerate_total_orders' );
+				delete_transient( 'con_renumerate_processed_count' );
 				set_transient( 'con_renumerate_complete', true, DAY_IN_SECONDS );
 				return;
 			}
@@ -364,10 +401,15 @@ if ( ! class_exists( 'Tyche\CON\Core' ) ) :
 				$this->add_order_number_meta( $order_id, true );
 			}
 
+			$processed = (int) get_transient( 'con_renumerate_processed_count' ) + count( $order_ids );
+			set_transient( 'con_renumerate_processed_count', $processed, HOUR_IN_SECONDS * 2 );
+
 			if ( count( $order_ids ) === $batch_size ) {
 				as_schedule_single_action( time(), 'con_renumerate_batch', array( $page + 1 ), 'con' );
 			} else {
 				delete_transient( 'con_renumerate_batch_in_progress' );
+				delete_transient( 'con_renumerate_total_orders' );
+				delete_transient( 'con_renumerate_processed_count' );
 				set_transient( 'con_renumerate_complete', true, DAY_IN_SECONDS );
 			}
 		}

--- a/languages/custom-order-numbers-for-woocommerce.po
+++ b/languages/custom-order-numbers-for-woocommerce.po
@@ -140,7 +140,7 @@ msgid "Enable"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:135
+#: src/screens/renumerateOrders.js:92
 msgid "With the help of this tool, you can change the custom order numbers for all the existing orders in a sequence and will maintain the sequence for the upcoming orders also."
 msgstr ""
 
@@ -533,35 +533,35 @@ msgid "Are you sure you want to reset all rules settings to their default values
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:96
-#: src/screens/renumerateOrders.js:105
+#: src/screens/renumerateOrders.js:53
+#: src/screens/renumerateOrders.js:62
 msgid "Error renumbering orders."
 msgstr ""
 
 #: build/admin.js:1
 #: src/app.js:74
-#: src/screens/renumerateOrders.js:120
-#: src/screens/renumerateOrders.js:149
+#: src/screens/renumerateOrders.js:77
+#: src/screens/renumerateOrders.js:106
 msgid "Renumber Orders"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:122
+#: src/screens/renumerateOrders.js:79
 msgid "Use this tool to reassign order numbers to all your existing orders in sequence."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:129
+#: src/screens/renumerateOrders.js:86
 msgid "Important:"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:130
+#: src/screens/renumerateOrders.js:87
 msgid "Before proceeding, please ensure you have created a complete backup of your database. This tool will modify existing order numbers and cannot be easily undone."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:136
+#: src/screens/renumerateOrders.js:93
 msgid "The starting order number will always be 1, and all orders will be numbered sequentially from there."
 msgstr ""
 
@@ -833,13 +833,11 @@ msgid "Upgrade to Pro"
 msgstr ""
 
 #: includes/class-core.php:98
-#: build/admin.js:1
-#: src/screens/renumerateOrders.js:54
 msgid "Renumeration complete. All order numbers have been updated."
 msgstr ""
 
 #: includes/class-core.php:111
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:84
+#: src/screens/renumerateOrders.js:41
 msgid "Custom order numbers are being renumbered in the background."
 msgstr ""

--- a/languages/custom-order-numbers-for-woocommerce.pot
+++ b/languages/custom-order-numbers-for-woocommerce.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-22T06:42:53+00:00\n"
+"POT-Creation-Date: 2026-06-23T05:41:46+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: custom-order-numbers-for-woocommerce\n"
@@ -46,14 +46,12 @@ msgid "Guest"
 msgstr ""
 
 #: includes/class-core.php:98
-#: build/admin.js:1
-#: src/screens/renumerateOrders.js:54
 msgid "Renumeration complete. All order numbers have been updated."
 msgstr ""
 
 #: includes/class-core.php:111
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:84
+#: src/screens/renumerateOrders.js:41
 msgid "Custom order numbers are being renumbered in the background."
 msgstr ""
 
@@ -623,40 +621,40 @@ msgid "Are you sure you want to reset all rules settings to their default values
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:96
-#: src/screens/renumerateOrders.js:105
+#: src/screens/renumerateOrders.js:53
+#: src/screens/renumerateOrders.js:62
 msgid "Error renumbering orders."
 msgstr ""
 
 #: build/admin.js:1
 #: src/app.js:74
-#: src/screens/renumerateOrders.js:120
-#: src/screens/renumerateOrders.js:149
+#: src/screens/renumerateOrders.js:77
+#: src/screens/renumerateOrders.js:106
 msgid "Renumber Orders"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:122
+#: src/screens/renumerateOrders.js:79
 msgid "Use this tool to reassign order numbers to all your existing orders in sequence."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:129
+#: src/screens/renumerateOrders.js:86
 msgid "Important:"
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:130
+#: src/screens/renumerateOrders.js:87
 msgid "Before proceeding, please ensure you have created a complete backup of your database. This tool will modify existing order numbers and cannot be easily undone."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:135
+#: src/screens/renumerateOrders.js:92
 msgid "With the help of this tool, you can change the custom order numbers for all the existing orders in a sequence and will maintain the sequence for the upcoming orders also."
 msgstr ""
 
 #: build/admin.js:1
-#: src/screens/renumerateOrders.js:136
+#: src/screens/renumerateOrders.js:93
 msgid "The starting order number will always be 1, and all orders will be numbered sequentially from there."
 msgstr ""
 

--- a/src/screens/renumerateOrders.js
+++ b/src/screens/renumerateOrders.js
@@ -1,4 +1,4 @@
-import { useEffect } from "@wordpress/element";
+import { useState, useEffect } from "@wordpress/element";
 import { useForm } from "react-hook-form";
 import {
     Card,
@@ -10,16 +10,20 @@ import {
     __experimentalHeading as Heading,
     Button,
     Notice,
+    ProgressBar,
     withNotices
 } from "@wordpress/components";
 import { __ } from "@wordpress/i18n";
-import { renumerateOrders } from "../data/api";
+import { renumerateOrders, getBatchStatus } from "../data/api";
 
 function RenumerateOrders( { noticeOperations, noticeUI } ) {
 
     const { handleSubmit, formState: { isSubmitting } } = useForm({
         defaultValues: {},
     });
+
+    const [ isRenumerating, setIsRenumerating ] = useState( false );
+    const [ progress, setProgress ] = useState( { processed: 0, total: 0 } );
 
     // Auto-dismiss notices after 4 seconds.
     useEffect( () => {
@@ -31,15 +35,63 @@ function RenumerateOrders( { noticeOperations, noticeUI } ) {
         }
     }, [ noticeUI ] );
 
+    // Poll batch-status while renumeration is running; update progress bar.
+    useEffect( () => {
+        if ( ! isRenumerating ) return;
+
+        let timeoutId;
+        let cancelled = false;
+        let delay = 2000;
+        const maxDelay = 10000;
+
+        const poll = async () => {
+            try {
+                const status = await getBatchStatus();
+                if ( cancelled ) return;
+
+                if ( status?.renumerate_total != null ) {
+                    setProgress( {
+                        processed: status.renumerate_processed ?? 0,
+                        total: status.renumerate_total,
+                    } );
+                }
+
+                if ( ! status?.renumerate_in_progress ) {
+                    setIsRenumerating( false );
+                    setProgress( { processed: 0, total: 0 } );
+                    noticeOperations.removeAllNotices();
+                    noticeOperations.createNotice( {
+                        status: 'success',
+                        content: __( 'Renumeration complete. All order numbers have been updated.', 'custom-order-numbers-for-woocommerce' ),
+                    } );
+                    return;
+                }
+            } catch {
+                if ( ! cancelled ) {
+                    setIsRenumerating( false );
+                    setProgress( { processed: 0, total: 0 } );
+                }
+                return;
+            }
+            delay = Math.min( delay * 1.5, maxDelay );
+            timeoutId = setTimeout( poll, delay );
+        };
+
+        timeoutId = setTimeout( poll, delay );
+
+        return () => {
+            cancelled = true;
+            clearTimeout( timeoutId );
+        };
+    }, [ isRenumerating ] );
+
     const onSubmit = async () => {
         try {
             const response = await renumerateOrders();
             noticeOperations.removeAllNotices();
             if ( response.scheduled ) {
-                noticeOperations.createNotice( {
-                    status: 'info',
-                    content: __( 'Custom order numbers are being renumbered in the background.', 'custom-order-numbers-for-woocommerce' ),
-                } );
+                setIsRenumerating( true );
+                setProgress( { processed: 0, total: response.total ?? 0 } );
             } else {
                 if ( response.error ) {
                     noticeOperations.createNotice( {
@@ -69,6 +121,10 @@ function RenumerateOrders( { noticeOperations, noticeUI } ) {
             content: __( 'Error renumbering orders.', 'custom-order-numbers-for-woocommerce' ),
         } );
     };
+
+    const progressPercent = progress.total > 0
+        ? Math.min( Math.round( ( progress.processed / progress.total ) * 100 ), 100 )
+        : 0;
 
     return (
         <VStack style={ { margin: '30px' } }>
@@ -102,13 +158,25 @@ function RenumerateOrders( { noticeOperations, noticeUI } ) {
 
                             <div className="con-renumerate-divider"></div>
 
+                            { isRenumerating && (
+                                <VStack style={ { marginBottom: '20px' } }>
+                                    <Text isBlock={ true }>
+                                        { progress.total > 0
+                                            ? __( `Renumbering orders… ${ progress.processed } / ${ progress.total }`, 'custom-order-numbers-for-woocommerce' )
+                                            : __( 'Renumbering orders…', 'custom-order-numbers-for-woocommerce' )
+                                        }
+                                    </Text>
+                                    <ProgressBar value={ progress.total > 0 ? progressPercent : undefined } />
+                                </VStack>
+                            ) }
+
                             <HStack spacing={ 3 } expanded={ false } justify="left">
                                 <Button
                                     className="con-renumerate-button"
                                     variant="primary"
                                     type="submit"
-                                    isBusy={ isSubmitting }
-                                    disabled={ isSubmitting }
+                                    isBusy={ isSubmitting || isRenumerating }
+                                    disabled={ isSubmitting || isRenumerating }
                                 >
                                     { __( 'Renumber Orders', 'custom-order-numbers-for-woocommerce' ) }
                                 </Button>

--- a/src/screens/renumerateOrders.js
+++ b/src/screens/renumerateOrders.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "@wordpress/element";
+import { useEffect } from "@wordpress/element";
 import { useForm } from "react-hook-form";
 import {
     Card,
@@ -13,15 +13,13 @@ import {
     withNotices
 } from "@wordpress/components";
 import { __ } from "@wordpress/i18n";
-import { renumerateOrders, getBatchStatus } from "../data/api";
+import { renumerateOrders } from "../data/api";
 
 function RenumerateOrders( { noticeOperations, noticeUI } ) {
 
     const { handleSubmit, formState: { isSubmitting } } = useForm({
         defaultValues: {},
     });
-
-    const [ isRenumerating, setIsRenumerating ] = useState( false );
 
     // Auto-dismiss notices after 4 seconds.
     useEffect( () => {
@@ -33,57 +31,23 @@ function RenumerateOrders( { noticeOperations, noticeUI } ) {
         }
     }, [ noticeUI ] );
 
-    // Poll batch-status while renumeration is running; show complete notice when done.
-    useEffect( () => {
-        if ( ! isRenumerating ) return;
-
-        let timeoutId;
-        let cancelled = false;
-        let delay = 3000;
-        const maxDelay = 30000;
-
-        const poll = async () => {
-            try {
-                const status = await getBatchStatus();
-                if ( cancelled ) return;
-                if ( ! status?.renumerate_in_progress ) {
-                    setIsRenumerating( false );
-                    noticeOperations.removeAllNotices();
-                    noticeOperations.createNotice( {
-                        status: 'success',
-                        content: __( 'Renumeration complete. All order numbers have been updated.', 'custom-order-numbers-for-woocommerce' ),
-                    } );
-                    return;
-                }
-            } catch {
-                if ( ! cancelled ) {
-                    setIsRenumerating( false );
-                }
-                return;
-            }
-            delay = Math.min( delay * 2, maxDelay );
-            timeoutId = setTimeout( poll, delay );
-        };
-
-        timeoutId = setTimeout( poll, delay );
-
-        return () => {
-            cancelled = true;
-            clearTimeout( timeoutId );
-        };
-    }, [ isRenumerating ] );
-
     const onSubmit = async () => {
         try {
             const response = await renumerateOrders();
             noticeOperations.removeAllNotices();
             if ( response.scheduled ) {
-                setIsRenumerating( true );
                 noticeOperations.createNotice( {
                     status: 'info',
                     content: __( 'Custom order numbers are being renumbered in the background.', 'custom-order-numbers-for-woocommerce' ),
                 } );
             } else {
+                if ( response.error ) {
+                    noticeOperations.createNotice( {
+                        status: 'error',
+                        content: __( `Error renumbering orders: ${ response.error }`, 'custom-order-numbers-for-woocommerce' ),
+                    } );
+                    return;
+                }
                 noticeOperations.createNotice( {
                     status: 'success',
                     content: __( `Renumeration complete. ${ response.total_renumerated } order(s) updated.`, 'custom-order-numbers-for-woocommerce' ),
@@ -143,8 +107,8 @@ function RenumerateOrders( { noticeOperations, noticeUI } ) {
                                     className="con-renumerate-button"
                                     variant="primary"
                                     type="submit"
-                                    isBusy={ isSubmitting || isRenumerating }
-                                    disabled={ isSubmitting || isRenumerating }
+                                    isBusy={ isSubmitting }
+                                    disabled={ isSubmitting }
                                 >
                                     { __( 'Renumber Orders', 'custom-order-numbers-for-woocommerce' ) }
                                 </Button>


### PR DESCRIPTION
When renumbering 1000s of orders, the message dispalyed 'undefined' when the process was scheduled. 

With this fix, a notice 'Custom order numbers are being renumbered in the background.' will be displayed and the process will run in the background. Once all orders have been renumbered, a successful admin notice will be displayed.

- Fixed "undefined order(s) updated" message shown when renumeration is scheduled via Action Scheduler — the response { scheduled: true } has no count, so the message was incorrectly interpolating undefined                 
- Added order count tracking during batch processing using transients (con_renumerate_total_orders, con_renumerate_processed_count)                 
- Updated /con/v1/batch-status to return renumerate_total and renumerate_processed                                                          - Added a live progress bar and counter (X / Y orders) in the Renumber Orders UI that polls batch status while processing and dismisses on completion       
                                                                              