### PR TITLE
Fix #177 The plugin displays {dynamic prefix} and {dynamic suffix} placeholders in order numbers.

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -880,11 +880,13 @@ if ( ! class_exists( 'Tyche\CON\Core' ) ) :
 					}
 
 					$data  = array(
-						'{prefix}'      => $prefix_data['custom'],
-						'{date_prefix}' => ( $prefix_data['date'] ? date_i18n( $prefix_data['date'], $custom_order_timestamp ) : '' ),
-						'{number}'      => sprintf( '%0' . $order_number_width . 's', $custom_order_number_by_width ),
-						'{suffix}'      => '',
-						'{date_suffix}' => '',
+						'{dynamic_prefix}' => $prefix_data['custom'],
+						'{prefix}'         => $prefix_data['custom'],
+						'{date_prefix}'    => ( $prefix_data['date'] ? date_i18n( $prefix_data['date'], $custom_order_timestamp ) : '' ),
+						'{number}'         => sprintf( '%0' . $order_number_width . 's', $custom_order_number_by_width ),
+						'{suffix}'         => '',
+						'{date_suffix}'    => '',
+						'{dynamic_suffix}' => '',
 					);
 
 					$final = str_replace( array_keys( $data ), $data, $template );


### PR DESCRIPTION
Fix #177 The plugin displays {dynamic prefix} and {dynamic suffix} placeholders in order numbers.

Fix – added dynamic prefix and suffix for data. so now it will fetch the prefix suffix value preoperly.